### PR TITLE
resolve #22 clean /Case/SuperBillDetails/@DiagnosisICDCodes:

### DIFF
--- a/data/src/main/java/net/paypredict/patient/cases/data/worklist/CaseIssueOutXml.kt
+++ b/data/src/main/java/net/paypredict/patient/cases/data/worklist/CaseIssueOutXml.kt
@@ -76,6 +76,8 @@ fun CaseHist.createOutXml(
 
     updateProvider(domDocument)
 
+    domDocument.cleanDiagnosisICDCodes()
+
     outFile.writer().use { writer ->
         writer.write(XML_PREFIX)
 
@@ -561,3 +563,27 @@ private const val XML_PREFIX = """<?xml version="1.0" encoding="utf-16" standalo
 
 private fun File.toInputSource(): InputSource =
     InputSource(readText().removePrefix(XML_PREFIX).reader())
+
+private val invalidICDs = setOf("", ".", "n/a")
+
+private fun DomDocument.cleanDiagnosisICDCodes() {
+    val element: Element =
+        getElementsByTagName("SuperBillDetails")
+            .toSequence()
+            .filterIsInstance<Element>()
+            .firstOrNull()
+            ?: return
+
+    val attrName = "DiagnosisICDCodes"
+
+    val codes =
+        element.getAttribute(attrName) ?: return
+
+    element.setAttribute(
+        attrName,
+        codes
+            .split(',')
+            .filter { it.trim() !in invalidICDs }
+            .joinToString(separator = ",")
+    )
+}

--- a/data/src/test/java/net/paypredict/patient/cases/data/worklist/TestCaseIssueOutXml.kt
+++ b/data/src/test/java/net/paypredict/patient/cases/data/worklist/TestCaseIssueOutXml.kt
@@ -1,9 +1,11 @@
 package net.paypredict.patient.cases.data.worklist
 
+import net.paypredict.patient.cases.PatientCases
 import net.paypredict.patient.cases.mongo.DBS.Collections.cases
 import net.paypredict.patient.cases.mongo._id
 
 fun main(args: Array<String>) {
+    PatientCases.client = "test"
     cases()
         .find(args.last()._id())
         .firstOrNull()


### PR DESCRIPTION
  fun DomDocument.cleanDiagnosisICDCodes() removes "", ".", "n/a"
  from comma separated ICD10 codes list